### PR TITLE
feat(api): add root endpoint for API discovery and metadata

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -59,4 +59,4 @@ USER kcs
 EXPOSE 8080
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["kcs-mcp", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["kcs-mcp", "serve", "--host", "0.0.0.0", "--port", "8080"]

--- a/docs/api/api-overview.md
+++ b/docs/api/api-overview.md
@@ -25,11 +25,12 @@ and provide accurate kernel development guidance.
 
 ## Quick Start
 
-1. **Authentication**: Obtain an auth token
-2. **Health Check**: Verify server status at `/health`
-3. **Search Code**: Use `/mcp/tools/search_code` for semantic search
-4. **Explore Symbols**: Get symbol info with `/mcp/tools/get_symbol`
-5. **Trace Calls**: Find callers with `/mcp/tools/who_calls`
+1. **API Discovery**: Start with `GET /` to discover available endpoints and capabilities
+2. **Authentication**: Obtain an auth token
+3. **Health Check**: Verify server status at `/health`
+4. **Search Code**: Use `/mcp/tools/search_code` for semantic search
+5. **Explore Symbols**: Get symbol info with `/mcp/tools/get_symbol`
+6. **Trace Calls**: Find callers with `/mcp/tools/who_calls`
 
 ## Constitutional Requirements
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -33,7 +33,7 @@ provides a standard way for clients to discover API capabilities.
   "version": "1.0.0",
   "description": "Model Context Protocol API for Linux kernel analysis",
   "mcp": {
-    "protocol_version": "2024-11-05",
+    "protocol_version": "2025-09-20",
     "capabilities": ["tools", "resources"]
   },
   "endpoints": {

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -4,9 +4,58 @@
 
 The KCS API provides endpoints for kernel analysis, organized into categories:
 
+- **Root**: API discovery and metadata (`/`)
 - **Tools**: MCP tools for kernel analysis (`/mcp/tools/*`)
-- **Resources**: MCP resources for data access (`/mcp/resources/*`)  
+- **Resources**: MCP resources for data access (`/mcp/resources/*`)
 - **System**: Health and metrics (`/health`, `/metrics`)
+
+## Root Endpoint
+
+### GET /
+
+**Summary**: API discovery and service metadata
+
+**Description**: Returns information about the KCS API including available endpoints, MCP capabilities,
+service metadata, and constitutional requirements. This endpoint does not require authentication and
+provides a standard way for clients to discover API capabilities.
+
+**Responses**:
+
+- **200**: Service metadata and API discovery information
+  - Content-Type: `application/json`
+
+**Response Schema**:
+
+```json
+{
+  "service": "kcs",
+  "title": "Kernel Context Server MCP API",
+  "version": "1.0.0",
+  "description": "Model Context Protocol API for Linux kernel analysis",
+  "mcp": {
+    "protocol_version": "2024-11-05",
+    "capabilities": ["tools", "resources"]
+  },
+  "endpoints": {
+    "health": "/health",
+    "metrics": "/metrics",
+    "mcp_tools": "/mcp/tools",
+    "mcp_resources": "/mcp/resources",
+    "docs": "/docs"
+  },
+  "constitutional_requirements": {
+    "read_only": true,
+    "citations_required": true,
+    "performance_target": "p95 < 600ms"
+  }
+}
+```
+
+**Example**:
+
+```bash
+curl http://localhost:8080/
+```
 
 ## MCP Tools
 

--- a/src/python/kcs_mcp/app.py
+++ b/src/python/kcs_mcp/app.py
@@ -15,7 +15,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from .database import Database, set_database
-from .models import ErrorResponse
+from .models import ErrorResponse, RootEndpointResponse
 from .resources import router as resources_router
 from .tools import router as tools_router
 
@@ -189,6 +189,30 @@ async def global_exception_handler(request: Request, exc: Exception) -> dict[str
         error="internal_server_error", message="An internal server error occurred"
     )
     return {"error": error_response.error, "message": error_response.message}
+
+
+@app.get("/", response_model=RootEndpointResponse)
+async def root() -> RootEndpointResponse:
+    """Root endpoint for API discovery and metadata."""
+    return RootEndpointResponse(
+        service="kcs",
+        title="Kernel Context Server MCP API",
+        version="1.0.0",
+        description="Model Context Protocol API for Linux kernel analysis",
+        mcp={"protocol_version": "2024-11-05", "capabilities": ["tools", "resources"]},
+        endpoints={
+            "health": "/health",
+            "metrics": "/metrics",
+            "mcp_tools": "/mcp/tools",
+            "mcp_resources": "/mcp/resources",
+            "docs": "/docs",
+        },
+        constitutional_requirements={
+            "read_only": True,
+            "citations_required": True,
+            "performance_target": "p95 < 600ms",
+        },
+    )
 
 
 @app.get("/health")

--- a/src/python/kcs_mcp/app.py
+++ b/src/python/kcs_mcp/app.py
@@ -199,7 +199,7 @@ async def root() -> RootEndpointResponse:
         title="Kernel Context Server MCP API",
         version="1.0.0",
         description="Model Context Protocol API for Linux kernel analysis",
-        mcp={"protocol_version": "2024-11-05", "capabilities": ["tools", "resources"]},
+        mcp={"protocol_version": "2025-09-20", "capabilities": ["tools", "resources"]},
         endpoints={
             "health": "/health",
             "metrics": "/metrics",

--- a/src/python/kcs_mcp/models/__init__.py
+++ b/src/python/kcs_mcp/models/__init__.py
@@ -702,7 +702,7 @@ class RootEndpointResponse(BaseModel):
                 "version": "1.0.0",
                 "description": "Model Context Protocol API for Linux kernel analysis",
                 "mcp": {
-                    "protocol_version": "2024-11-05",
+                    "protocol_version": "2025-09-20",
                     "capabilities": ["tools", "resources"],
                 },
                 "endpoints": {

--- a/src/python/kcs_mcp/models/__init__.py
+++ b/src/python/kcs_mcp/models/__init__.py
@@ -680,6 +680,47 @@ class TraverseCallGraphResponse(BaseModel):
     )
 
 
+# Root endpoint response
+class RootEndpointResponse(BaseModel):
+    """Root endpoint API discovery response."""
+
+    service: str = Field(..., description="Service name")
+    title: str = Field(..., description="API title")
+    version: str = Field(..., description="API version")
+    description: str = Field(..., description="API description")
+    mcp: dict[str, Any] = Field(..., description="MCP protocol information")
+    endpoints: dict[str, str] = Field(..., description="Available endpoints")
+    constitutional_requirements: dict[str, Any] = Field(
+        ..., description="Constitutional requirements"
+    )
+
+    class Config:
+        json_schema_extra: typing.ClassVar[dict[str, typing.Any]] = {
+            "example": {
+                "service": "kcs",
+                "title": "Kernel Context Server MCP API",
+                "version": "1.0.0",
+                "description": "Model Context Protocol API for Linux kernel analysis",
+                "mcp": {
+                    "protocol_version": "2024-11-05",
+                    "capabilities": ["tools", "resources"],
+                },
+                "endpoints": {
+                    "health": "/health",
+                    "metrics": "/metrics",
+                    "mcp_tools": "/mcp/tools",
+                    "mcp_resources": "/mcp/resources",
+                    "docs": "/docs",
+                },
+                "constitutional_requirements": {
+                    "read_only": True,
+                    "citations_required": True,
+                    "performance_target": "p95 < 600ms",
+                },
+            }
+        }
+
+
 # Error response
 class ErrorResponse(BaseModel):
     """Standard error response."""
@@ -1177,6 +1218,7 @@ __all__ = [
     "ProcessChunkRequest",
     "ProcessChunkResponse",
     "ProcessingStatus",
+    "RootEndpointResponse",
     "SearchCodeRequest",
     "SearchCodeResponse",
     "SearchDocsRequest",

--- a/tests/contract/test_root_endpoint.py
+++ b/tests/contract/test_root_endpoint.py
@@ -1,0 +1,136 @@
+"""
+Contract tests for root endpoint.
+
+These tests verify the API contract for the root endpoint (GET /).
+They MUST fail before implementation and pass after.
+"""
+
+import os
+from typing import Any
+
+import httpx
+import pytest
+import requests
+
+
+# Skip tests requiring MCP server when it's not running
+def is_mcp_server_running() -> bool:
+    """Check if MCP server is accessible."""
+    try:
+        response = requests.get("http://localhost:8080", timeout=2)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+skip_without_mcp_server = pytest.mark.skipif(
+    not is_mcp_server_running(), reason="MCP server not running"
+)
+
+# Skip integration tests in CI environments unless explicitly enabled
+skip_integration_in_ci = pytest.mark.skipif(
+    os.getenv("CI") == "true" and os.getenv("RUN_INTEGRATION_TESTS") != "true",
+    reason="Integration tests skipped in CI (set RUN_INTEGRATION_TESTS=true to enable)",
+)
+
+# Test configuration
+MCP_BASE_URL = "http://localhost:8080"
+
+
+class TestRootEndpoint:
+    """Test cases for root endpoint API discovery."""
+
+    @skip_without_mcp_server
+    @skip_integration_in_ci
+    async def test_root_endpoint_exists(self):
+        """Test that root endpoint exists and returns 200."""
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(f"{MCP_BASE_URL}/")
+
+        # Should not return 404 (endpoint exists)
+        assert response.status_code == 200, "Root endpoint should exist and return 200"
+
+    @skip_without_mcp_server
+    @skip_integration_in_ci
+    async def test_root_endpoint_schema(self):
+        """Test that root endpoint returns correct schema."""
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(f"{MCP_BASE_URL}/")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify required fields
+        required_fields = [
+            "service",
+            "title",
+            "version",
+            "description",
+            "mcp",
+            "endpoints",
+            "constitutional_requirements",
+        ]
+
+        for field in required_fields:
+            assert field in data, f"Root response should contain '{field}' field"
+
+        # Verify specific values
+        assert data["service"] == "kcs", "Service should be 'kcs'"
+        assert data["title"] == "Kernel Context Server MCP API", (
+            "Title should match expected value"
+        )
+        assert data["version"] == "1.0.0", "Version should be '1.0.0'"
+        assert "Model Context Protocol" in data["description"], (
+            "Description should mention MCP"
+        )
+
+        # Verify MCP section
+        assert "protocol_version" in data["mcp"], "MCP should have protocol_version"
+        assert "capabilities" in data["mcp"], "MCP should have capabilities"
+        assert isinstance(data["mcp"]["capabilities"], list), (
+            "MCP capabilities should be a list"
+        )
+
+        # Verify endpoints section
+        expected_endpoints = ["health", "metrics", "mcp_tools", "mcp_resources", "docs"]
+        for endpoint in expected_endpoints:
+            assert endpoint in data["endpoints"], (
+                f"Endpoints should contain '{endpoint}'"
+            )
+
+        # Verify constitutional requirements
+        constitutional = data["constitutional_requirements"]
+        assert "read_only" in constitutional, (
+            "Constitutional requirements should specify read_only"
+        )
+        assert "citations_required" in constitutional, (
+            "Constitutional requirements should specify citations_required"
+        )
+        assert "performance_target" in constitutional, (
+            "Constitutional requirements should specify performance_target"
+        )
+
+    @skip_without_mcp_server
+    @skip_integration_in_ci
+    async def test_root_endpoint_no_auth_required(self):
+        """Test that root endpoint doesn't require authentication."""
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            # Request without authentication
+            response = await client.get(f"{MCP_BASE_URL}/")
+
+        # Should return 200, not 401
+        assert response.status_code == 200, (
+            "Root endpoint should not require authentication"
+        )
+
+    @skip_without_mcp_server
+    @skip_integration_in_ci
+    async def test_root_endpoint_content_type(self):
+        """Test that root endpoint returns JSON content type."""
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(f"{MCP_BASE_URL}/")
+
+        assert response.status_code == 200
+        assert "application/json" in response.headers.get("content-type", ""), (
+            "Root endpoint should return JSON"
+        )


### PR DESCRIPTION
## Summary

- Implements GET / endpoint for API discovery and metadata per issue #7
- Returns service information, MCP capabilities, available endpoints, and constitutional requirements
- No authentication required for public metadata access
- Follows modern API best practices for service discovery

## Changes Made

### API Implementation
- Added `RootEndpointResponse` Pydantic model with comprehensive schema
- Implemented `GET /` endpoint handler in FastAPI app
- Added endpoint to exports and proper typing

### Testing
- Created comprehensive contract test suite in `test_root_endpoint.py`
- Tests cover endpoint existence, schema validation, authentication requirements, and content type
- All tests pass with the running MCP server

### Documentation
- Updated API endpoints documentation with detailed root endpoint specs
- Added root endpoint to API overview quick start guide
- Included example usage and response schema

### Infrastructure
- Fixed Docker configuration issue where MCP server was missing `serve` command
- Server now starts correctly and serves the new endpoint

## Test Plan

- [x] Endpoint returns correct JSON schema with all required fields
- [x] No authentication required for public metadata
- [x] Proper HTTP status codes and content types
- [x] All contract tests pass
- [x] Server starts and runs correctly in Docker
- [x] Linting and type checking pass

## API Example

```bash
curl http://localhost:8080/
```

Returns:
```json
{
  "service": "kcs",
  "title": "Kernel Context Server MCP API", 
  "version": "1.0.0",
  "description": "Model Context Protocol API for Linux kernel analysis",
  "mcp": {
    "protocol_version": "2025-09-20",
    "capabilities": ["tools", "resources"]
  },
  "endpoints": {
    "health": "/health",
    "metrics": "/metrics", 
    "mcp_tools": "/mcp/tools",
    "mcp_resources": "/mcp/resources",
    "docs": "/docs"
  },
  "constitutional_requirements": {
    "read_only": true,
    "citations_required": true,
    "performance_target": "p95 < 600ms"
  }
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)